### PR TITLE
#39553 Convert non-speaking erros of giropay.

### DIFF
--- a/Action/Api/CaptureAction.php
+++ b/Action/Api/CaptureAction.php
@@ -48,6 +48,14 @@ class CaptureAction extends BaseApiAwareAction
         }
 
         if (Api::STATUS_ERROR === $response[Api::FIELD_STATUS]) {
+            if (array_key_exists(Api::FIELD_PAYMENT_METHOD, $model)) {
+                if ($this->isGiropayError1087($model, $response)) {
+                    $response[Api::FIELD_ERROR_CODE]       = 885;
+                    $response[Api::FIELD_ERROR_MESSAGE]    = 'Bank is not supported by giropay';
+                    $response[Api::FIELD_CUSTOMER_MESSAGE] = 'Bank is not supported by giropay';
+                }
+            }
+
             $model[Api::FIELD_CUSTOMER_MESSAGE] = $response[Api::FIELD_CUSTOMER_MESSAGE];
             $model[Api::FIELD_ERROR_CODE] = $response[Api::FIELD_ERROR_CODE];
             $model[Api::FIELD_ERROR_MESSAGE] = $response[Api::FIELD_ERROR_MESSAGE];
@@ -67,5 +75,17 @@ class CaptureAction extends BaseApiAwareAction
             $request instanceof Capture &&
             $request->getModel() instanceof \ArrayAccess
         ;
+    }
+
+    /**
+     * @param $model
+     * @param $response
+     *
+     * @return bool
+     */
+    protected function isGiropayError1087($model, $response)
+    {
+        return $model[Api::FIELD_PAYMENT_METHOD] == Api::PAYMENT_METHOD_GIROPAY
+               && (int)$response[Api::FIELD_ERROR_CODE] == 1087;
     }
 }

--- a/Action/Api/ConvertGiropayErrorsAction.php
+++ b/Action/Api/ConvertGiropayErrorsAction.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright 2016 Valiton GmbH
+ *
+ * This file is part of a package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valiton\Payum\Payone\Action\Api;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Valiton\Payum\Payone\Api;
+use Valiton\Payum\Payone\Request\Api\ConvertGiropayErrors;
+
+/**
+ * ConvertGiropayErrorsAction.
+ */
+class ConvertGiropayErrorsAction implements ActionInterface
+{
+    /**
+     * Rewrites non speaking error messages of the case, that the bank is not supported.
+     *
+     * @param ConvertGiropayErrors $request
+     *
+     * @throws \Payum\Core\Exception\RequestNotSupportedException if the action dose not support the request.
+     */
+    public function execute($request)
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+        $model    = ArrayObject::ensureArrayObject($request->getModel());
+        $response = $request->getResponse();
+
+        if (Api::STATUS_ERROR != $response[Api::FIELD_STATUS]
+            || !array_key_exists(Api::FIELD_PAYMENT_METHOD, $model)
+            || $model[Api::FIELD_PAYMENT_METHOD] != Api::PAYMENT_METHOD_GIROPAY
+        ) {
+            return;
+        }
+
+        if ($this->isNonSpeakingErrorMessage($model, $response)) {
+            $response[Api::FIELD_ERROR_CODE]       = '885';
+            $response[Api::FIELD_ERROR_MESSAGE]    = 'Bank is not supported by giropay';
+            $response[Api::FIELD_CUSTOMER_MESSAGE] = 'Bank is not supported by giropay';
+        }
+    }
+
+    /**
+     * @param mixed $request
+     *
+     * @return boolean
+     */
+    public function supports($request)
+    {
+        return $request instanceof ConvertGiropayErrors
+               && $request->getModel() instanceof \ArrayAccess
+               && $request->getResponse() instanceof \ArrayAccess;
+    }
+
+    /**
+     * @param $model
+     * @param $response
+     *
+     * @return bool
+     */
+    protected function isNonSpeakingErrorMessage($model, $response)
+    {
+        $errorCode = (int)$response[Api::FIELD_ERROR_CODE];
+
+        return $errorCode == 887 || $errorCode == 1087;
+    }
+}

--- a/PayoneGatewayFactory.php
+++ b/PayoneGatewayFactory.php
@@ -57,6 +57,8 @@ class PayoneGatewayFactory extends GatewayFactory
             },
             'payum.action.api.refund' => new Action\Api\RefundAction(),
 
+            'payum.action.api.convert_giropay_errors' => new Action\Api\ConvertGiropayErrorsAction(),
+
             'payum.extension.invalidate_notify_token' => function (ArrayObject $config) {
                 return new InvalidateNotifyTokenExtension($config['payum.security.token_storage']);
             }

--- a/Request/Api/ConvertGiropayErrors.php
+++ b/Request/Api/ConvertGiropayErrors.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright 2016 Valiton GmbH
+ *
+ * This file is part of a package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valiton\Payum\Payone\Request\Api;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Generic;
+
+/**
+ * ConvertGiropayErrors.
+ */
+class ConvertGiropayErrors extends Generic
+{
+    /**
+     * @var ArrayObject
+     */
+    protected $response;
+
+    /**
+     * ConvertGiropayErrors constructor.
+     *
+     * @param mixed       $model
+     * @param ArrayObject $response
+     */
+    public function __construct($model, ArrayObject $response)
+    {
+        parent::__construct($model);
+        $this->response = $response;
+    }
+
+    /**
+     * @return ArrayObject
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/Tests/Action/Api/CaptureActionTest.php
+++ b/Tests/Action/Api/CaptureActionTest.php
@@ -2,9 +2,12 @@
 
 namespace Valiton\Payum\Payone\Tests\Api\Action;
 
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\GatewayInterface;
 use Valiton\Payum\Payone\Action\Api\CaptureAction;
 use Valiton\Payum\Payone\Api;
 use Valiton\Payum\Payone\Request\Api\Capture;
+use Valiton\Payum\Payone\Request\Api\ConvertGiropayErrors;
 use Valiton\Payum\Payone\Tests\Action\AbstractActionTest;
 
 class CaptureActionTest extends AbstractActionTest
@@ -14,28 +17,48 @@ class CaptureActionTest extends AbstractActionTest
      */
     protected $action;
 
-    protected $actionClass = CaptureAction::class;
+    protected $actionClass  = CaptureAction::class;
 
     protected $requestClass = Capture::class;
 
     public function testStatusStaysAuthorizedIfError()
     {
-        $api = $this->getMockBuilder(Api::class)
-            ->disableOriginalConstructor()
-            ->getMock()
+        $model   = new ArrayObject([Api::FIELD_STATUS => 'authorized']);
+        $request = new $this->requestClass($model);
+
+        $api     = $this->getMockBuilder(Api::class)
+                        ->disableOriginalConstructor()
+                        ->getMock()
         ;
+        $gateway = $this->getMock(GatewayInterface::class);
 
         $api
             ->expects($this->once())
             ->method('capture')
             ->willReturn([
-                'status' => 'ERROR',
-            ]);
+                             'status' => 'ERROR',
+                         ]
+            )
+        ;
+
+        $gateway
+            ->expects($this->once())
+            ->method('execute')
+            ->with(
+                $this->callback(
+                    function (ConvertGiropayErrors $request) use ($model) {
+                        $this->assertEquals($model, $request->getModel());
+                        $this->assertEquals(['status' => 'ERROR'], $request->getResponse()->toUnsafeArray());
+
+                        return true;
+                    }
+                )
+            )
+        ;
 
         $this->action->setApi($api);
+        $this->action->setGateway($gateway);
 
-        $model = new \ArrayObject([Api::FIELD_STATUS => 'authorized']);
-        $request = new $this->requestClass($model);
         $this->action->execute($request);
 
         $this->assertEquals('authorized', $model[Api::FIELD_STATUS]);
@@ -44,67 +67,25 @@ class CaptureActionTest extends AbstractActionTest
     public function testStatusChangesToCaptureIfApproved()
     {
         $api = $this->getMockBuilder(Api::class)
-            ->disableOriginalConstructor()
-            ->getMock()
+                    ->disableOriginalConstructor()
+                    ->getMock()
         ;
 
         $api
             ->expects($this->once())
             ->method('capture')
             ->willReturn([
-                'status' => 'APPROVED',
-            ]);
+                             'status' => 'APPROVED',
+                         ]
+            )
+        ;
 
         $this->action->setApi($api);
 
-        $model = new \ArrayObject([Api::FIELD_STATUS => 'authorized']);
+        $model   = new \ArrayObject([Api::FIELD_STATUS => 'authorized']);
         $request = new $this->requestClass($model);
         $this->action->execute($request);
 
         $this->assertEquals('captured', $model[Api::FIELD_STATUS]);
-    }
-
-    public function testRewriteGiropayError1087To885()
-    {
-        $api = $this
-            ->getMockBuilder(Api::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $api
-            ->expects($this->once())
-            ->method('capture')
-            ->with(
-                [
-                    Api::FIELD_STATUS         => 'authorized',
-                    Api::FIELD_PAYMENT_METHOD => Api::PAYMENT_METHOD_GIROPAY
-                ]
-            )
-            ->willReturn(
-                [
-                    'status'                    => 'ERROR',
-                    Api::FIELD_CUSTOMER_MESSAGE => 'error happened',
-                    Api::FIELD_ERROR_CODE       => '1087',
-                    Api::FIELD_ERROR_MESSAGE    => 'error happened',
-                ]
-            )
-        ;
-
-        $this->action->setApi($api);
-
-        $model   = new \ArrayObject(
-            [
-                Api::FIELD_STATUS         => 'authorized',
-                Api::FIELD_PAYMENT_METHOD => Api::PAYMENT_METHOD_GIROPAY
-            ]
-        );
-        $request = new $this->requestClass($model);
-        $this->action->execute($request);
-
-        $this->assertEquals('authorized', $model[Api::FIELD_STATUS]);
-        $this->assertEquals(885, $model[Api::FIELD_ERROR_CODE]);
-        $this->assertEquals('Bank is not supported by giropay', $model[Api::FIELD_ERROR_MESSAGE]);
-        $this->assertEquals('Bank is not supported by giropay', $model[Api::FIELD_CUSTOMER_MESSAGE]);
     }
 }

--- a/Tests/Action/Api/ConvertGiropayErrorsActionTest.php
+++ b/Tests/Action/Api/ConvertGiropayErrorsActionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Valiton\Payum\Payone\Tests\Api\Action;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Tests\GenericActionTest;
+use Valiton\Payum\Payone\Action\Api\ConvertGiropayErrorsAction;
+use Valiton\Payum\Payone\Api;
+use Valiton\Payum\Payone\Request\Api\ConvertGiropayErrors;
+use Valiton\Payum\Payone\Request\Generic;
+
+/**
+ * Tests of ConvertGiropayErrorsAction.
+ *
+ * @group unit
+ */
+class ConvertGiropayErrorsActionTest extends GenericActionTest
+{
+    /**
+     * @var ConvertGiropayErrorsAction
+     */
+    protected $action;
+
+    protected $actionClass  = ConvertGiropayErrorsAction::class;
+
+    protected $requestClass = ConvertGiropayErrors::class;
+
+    public function provideSupportedRequests()
+    {
+        return [
+            [new $this->requestClass([], new ArrayObject())],
+            [new $this->requestClass(new \ArrayObject(), new ArrayObject())],
+        ];
+    }
+
+    public function provideNotSupportedRequests()
+    {
+        return [
+            ['foo', new ArrayObject()],
+            [['foo'], new ArrayObject()],
+            [new \stdClass(), new ArrayObject()],
+            [new $this->requestClass('foo', new ArrayObject())],
+            [new $this->requestClass(new \stdClass(), new ArrayObject())],
+            [$this->getMockForAbstractClass(Generic::class, [[]])],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function nonSpeakingErrorsProvider()
+    {
+        return [
+            ['1087', 'error happened'],
+            ['887', 'error happened']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider nonSpeakingErrorsProvider
+     *
+     * @param $errorCode
+     * @param $errorMessage
+     */
+    public function shouldRewriteGiropayNonSpeakingErrors($errorCode, $errorMessage)
+    {
+        $model    = new ArrayObject(
+            [
+                Api::FIELD_PAYMENT_METHOD => Api::PAYMENT_METHOD_GIROPAY
+            ]
+        );
+        $response = new ArrayObject(
+            [
+                Api::FIELD_STATUS           => Api::STATUS_ERROR,
+                Api::FIELD_CUSTOMER_MESSAGE => $errorMessage,
+                Api::FIELD_ERROR_CODE       => $errorCode,
+                Api::FIELD_ERROR_MESSAGE    => $errorMessage,
+            ]
+        );
+        $request  = new $this->requestClass($model, $response);
+        $this->action->execute($request);
+
+        $this->assertEquals('885', $response[Api::FIELD_ERROR_CODE]);
+        $this->assertEquals('Bank is not supported by giropay', $response[Api::FIELD_ERROR_MESSAGE]);
+        $this->assertEquals('Bank is not supported by giropay', $response[Api::FIELD_CUSTOMER_MESSAGE]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotRewritePtherGiropayErrors()
+    {
+        $model    = new ArrayObject(
+            [
+                Api::FIELD_PAYMENT_METHOD => Api::PAYMENT_METHOD_GIROPAY
+            ]
+        );
+        $response = new ArrayObject(
+            [
+                Api::FIELD_STATUS           => Api::STATUS_ERROR,
+                Api::FIELD_CUSTOMER_MESSAGE => 'other error',
+                Api::FIELD_ERROR_CODE       => '11',
+                Api::FIELD_ERROR_MESSAGE    => 'other error',
+            ]
+        );
+        $request  = new $this->requestClass($model, $response);
+        $this->action->execute($request);
+
+        $this->assertEquals('11', $response[Api::FIELD_ERROR_CODE]);
+        $this->assertEquals('other error', $response[Api::FIELD_ERROR_MESSAGE]);
+        $this->assertEquals('other error', $response[Api::FIELD_CUSTOMER_MESSAGE]);
+    }
+}


### PR DESCRIPTION
# Introduction
Giropay send on invalid bic, maybe by different reasons, a "BIC error". But for a customer is that not understandable.

This case converts this "non-speaking errors" from giropay to corresponding errors.

The Error Codes `887` and `1087` on payment method "giropay", will be mapped to error `885`.

This happend on `capture` and `pre auhtorize`. For safety will it also be done on `authorize` even if Giropay currently no `auhtorize` action supports.

# Changelog
## Add
* Error convert action and request.
  * Handle error "{BIC} fault" as "Bank do not support giropay"
  * Handle error "887 Invalid BIC" as "Bank do not support giropay"

## Change
* Call error convert action in error case of pre-authorize, authorize and capture