### PR TITLE
Limit Reference Number to 20 Chars

### DIFF
--- a/Action/ConvertPaymentAction.php
+++ b/Action/ConvertPaymentAction.php
@@ -39,7 +39,7 @@ class ConvertPaymentAction extends GatewayAwareAction
 
         $details = ArrayObject::ensureArrayObject($payment->getDetails());
 
-        $details[Api::FIELD_REFERENCE] = $payment->getNumber();
+        $details[Api::FIELD_REFERENCE] = substr($payment->getNumber(), 0, 20);
         $details[Api::FIELD_AMOUNT] = $payment->getTotalAmount();
         $details[Api::FIELD_CURRENCY_CODE] = $payment->getCurrencyCode();
         $details[Api::FIELD_NARRATIVE_TEXT] = $payment->getDescription();


### PR DESCRIPTION
The latest payum server implementation created a payment number which was longer than 20 chars.
The payment number is being used as a reference number but the reference number is limited to 20 chars. If the simple substring is not enough than we need to hash the payment number with a hash that is not longer than 20 chars.